### PR TITLE
Add OIDC Configuration to Terraform

### DIFF
--- a/infra/tf-app/terraform.tf
+++ b/infra/tf-app/terraform.tf
@@ -4,6 +4,7 @@ terraform {
     storage_account_name = "kare0041githubactions"
     container_name       = "tfstate"
     key                  = "prod.app.tfstate"
+     use_oidc            = true
   }
 
   required_providers {
@@ -16,5 +17,6 @@ terraform {
 
 provider "azurerm" {
   features {}
+  use_oidc = true
 }
 


### PR DESCRIPTION
- Enabled OIDC in backend and provider blocks of terraform.tf
- Required for secure GitHub Actions authentication
- Please review and approve for merging into main